### PR TITLE
Add fuzzy search

### DIFF
--- a/content.js
+++ b/content.js
@@ -114,6 +114,17 @@ function parseSearchInput(input) {
   return { includeTerms, excludeTerms };
 }
 
+function fuzzyMatch(query, text) {
+  if (!query) return true;
+  const normalizedQuery = removeDiacritics(query.toLowerCase().replace(/\s+/g, ''));
+  const normalizedText = removeDiacritics(text.toLowerCase());
+
+  const escaped = normalizedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = escaped.split('').join('.*');
+  const regex = new RegExp(pattern);
+  return regex.test(normalizedText);
+}
+
 function filterPlaces(query, excludeQuery = []) {
   const listContainer = document.querySelector('div[role="main"]');
   if (!listContainer) return;
@@ -242,12 +253,11 @@ function filterPlaces(query, excludeQuery = []) {
     
     // Apply include filter (if there's a query)
     if (query && query.length > 0) {
-      const normalizedQuery = removeDiacritics(query);
-      const isMatchByName = normalizedName.includes(normalizedQuery);
-      const isMatchByTypePrice = normalizedTypePrice.includes(normalizedQuery);
-      const isMatchByNote = normalizedNote.includes(normalizedQuery);
+      const isMatchByName = fuzzyMatch(query, itemData.name);
+      const isMatchByTypePrice = fuzzyMatch(query, itemData.typePrice);
+      const isMatchByNote = fuzzyMatch(query, itemData.note);
       const queryFound = isMatchByName || isMatchByTypePrice || isMatchByNote;
-      
+
       if (!queryFound) {
         shouldShow = false;
       }

--- a/content.js
+++ b/content.js
@@ -124,10 +124,13 @@ function fuzzyMatch(query, text) {
 
   // Check cache first for performance optimization
   if (!regexCache.has(normalizedQuery)) {
-    const escaped = normalizedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const pattern = escaped.split('').join('.*');
+    const pattern = normalizedQuery
+      .split('')
+      .map((char) => char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      .join('.*');
+
     regexCache.set(normalizedQuery, new RegExp(pattern));
-    
+
     // Prevent cache from growing too large
     if (regexCache.size > 100) {
       // Remove oldest entries (first inserted)

--- a/content.js
+++ b/content.js
@@ -1,6 +1,9 @@
 let lastQuery = '';
 let lastExcludeQuery = [];
 
+// Cache for compiled regex patterns to improve performance
+const regexCache = new Map();
+
 function removeDiacritics(str) {
   return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 }
@@ -119,10 +122,21 @@ function fuzzyMatch(query, text) {
   const normalizedQuery = removeDiacritics(query.toLowerCase().replace(/\s+/g, ''));
   const normalizedText = removeDiacritics(text.toLowerCase());
 
-  const escaped = normalizedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = escaped.split('').join('.*');
-  const regex = new RegExp(pattern);
-  return regex.test(normalizedText);
+  // Check cache first for performance optimization
+  if (!regexCache.has(normalizedQuery)) {
+    const escaped = normalizedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = escaped.split('').join('.*');
+    regexCache.set(normalizedQuery, new RegExp(pattern));
+    
+    // Prevent cache from growing too large
+    if (regexCache.size > 100) {
+      // Remove oldest entries (first inserted)
+      const firstKey = regexCache.keys().next().value;
+      regexCache.delete(firstKey);
+    }
+  }
+  
+  return regexCache.get(normalizedQuery).test(normalizedText);
 }
 
 function filterPlaces(query, excludeQuery = []) {

--- a/tests/unit/content.test.js
+++ b/tests/unit/content.test.js
@@ -12,7 +12,8 @@ describe('Content Script Unit Tests', () => {
   let document;
   let removeDiacritics; // To hold the function from the script
   let getScrollableListContainer; // To hold the function from the script
-  let filterPlaces; 
+  let filterPlaces;
+  let fuzzyMatch;
 
   // Helper to create a basic list item structure
   const createPlaceItem = (id, name, typePrice, note, hasImage = true) => {
@@ -72,7 +73,8 @@ describe('Content Script Unit Tests', () => {
     // Assign the function from the script's global scope (within JSDOM)
     removeDiacritics = window.removeDiacritics;
     getScrollableListContainer = window.getScrollableListContainer;
-    filterPlaces = window.filterPlaces; 
+    filterPlaces = window.filterPlaces;
+    fuzzyMatch = window.fuzzyMatch;
     // Mock the global lastQuery, as filterPlaces uses it when called from autoScrollListToLoadAll
     window.lastQuery = '';
   });
@@ -116,6 +118,16 @@ describe('Content Script Unit Tests', () => {
 
     test('should handle complex strings with various diacritics', () => {
       expect(removeDiacritics('déjà vu à la Pâtisserie')).toBe('deja vu a la Patisserie');
+    });
+  });
+
+  describe('fuzzyMatch', () => {
+    test('should match text with characters in order', () => {
+      expect(fuzzyMatch('cfe sup', 'Coffee Supreme')).toBe(true);
+    });
+
+    test('should not match when characters are not in order', () => {
+      expect(fuzzyMatch('cfesmu', 'Coffee Supreme')).toBe(false);
     });
   });
 
@@ -234,6 +246,18 @@ describe('Content Script Unit Tests', () => {
       listContainer.appendChild(item2);
 
       filterPlaces('pizza place');
+
+      expect(item1.style.display).toBe('');
+      expect(item2.style.display).toBe('none');
+    });
+
+    test('should filter by name using fuzzy search', () => {
+      const item1 = createPlaceItem('item1', 'Coffee Supreme', 'Cafe', '');
+      const item2 = createPlaceItem('item2', 'Book Store', 'Retail', '');
+      listContainer.appendChild(item1);
+      listContainer.appendChild(item2);
+
+      filterPlaces('cfe sup');
 
       expect(item1.style.display).toBe('');
       expect(item2.style.display).toBe('none');

--- a/tests/unit/content.test.js
+++ b/tests/unit/content.test.js
@@ -150,7 +150,7 @@ describe('Content Script Unit Tests', () => {
     test('should handle special characters in queries', () => {
       expect(fuzzyMatch('c&f', 'Coffee & Food')).toBe(true);
       expect(fuzzyMatch('$10', '$10-20 range')).toBe(true);
-      expect(fuzzyMatch('3.5*', '3.5 star rating')).toBe(true);
+      expect(fuzzyMatch('3.5*', '3.5* star rating')).toBe(true);
       expect(fuzzyMatch('50%', '50% off sale')).toBe(true);
     });
 

--- a/tests/unit/content.test.js
+++ b/tests/unit/content.test.js
@@ -129,6 +129,80 @@ describe('Content Script Unit Tests', () => {
     test('should not match when characters are not in order', () => {
       expect(fuzzyMatch('cfesmu', 'Coffee Supreme')).toBe(false);
     });
+
+    test('should handle single character queries', () => {
+      expect(fuzzyMatch('c', 'Coffee')).toBe(true);
+      expect(fuzzyMatch('f', 'Coffee')).toBe(true);
+      expect(fuzzyMatch('x', 'Coffee')).toBe(false);
+    });
+
+    test('should handle empty queries', () => {
+      expect(fuzzyMatch('', 'Coffee Supreme')).toBe(true);
+      expect(fuzzyMatch('', '')).toBe(true);
+    });
+
+    test('should handle very long queries', () => {
+      const longQuery = 'coffeesupremedeluxespecialtyroasters';
+      expect(fuzzyMatch(longQuery, 'Coffee Supreme Deluxe Specialty Roasters')).toBe(true);
+      expect(fuzzyMatch(longQuery, 'Short text')).toBe(false);
+    });
+
+    test('should handle special characters in queries', () => {
+      expect(fuzzyMatch('c&f', 'Coffee & Food')).toBe(true);
+      expect(fuzzyMatch('$10', '$10-20 range')).toBe(true);
+      expect(fuzzyMatch('3.5*', '3.5 star rating')).toBe(true);
+      expect(fuzzyMatch('50%', '50% off sale')).toBe(true);
+    });
+
+    test('should handle mixed case correctly', () => {
+      expect(fuzzyMatch('CfE', 'Coffee')).toBe(true);
+      expect(fuzzyMatch('cFe', 'COFFEE')).toBe(true);
+      expect(fuzzyMatch('CoFfEe', 'coffee supreme')).toBe(true);
+    });
+
+    test('should handle diacritics in both query and text', () => {
+      expect(fuzzyMatch('cafe', 'Café')).toBe(true);
+      expect(fuzzyMatch('café', 'Cafe')).toBe(true);
+      expect(fuzzyMatch('naï', 'Naïve Restaurant')).toBe(true);
+      expect(fuzzyMatch('patiss', 'Pâtisserie')).toBe(true);
+    });
+
+    test('should handle whitespace in queries', () => {
+      expect(fuzzyMatch('cof fee', 'Coffee Supreme')).toBe(true); // Spaces should be removed
+      expect(fuzzyMatch('  cfe  ', 'Coffee')).toBe(true); // Leading/trailing spaces
+      expect(fuzzyMatch('c f e', 'Coffee')).toBe(true); // Multiple spaces
+    });
+
+    test('should handle regex special characters correctly', () => {
+      expect(fuzzyMatch('a.b', 'Apple.Banana')).toBe(true);
+      expect(fuzzyMatch('a*b', 'Apple*Banana')).toBe(true);
+      expect(fuzzyMatch('a+b', 'Apple+Banana')).toBe(true);
+      expect(fuzzyMatch('a?b', 'Apple?Banana')).toBe(true);
+      expect(fuzzyMatch('a^b', 'Apple^Banana')).toBe(true);
+      expect(fuzzyMatch('a$b', 'Apple$Banana')).toBe(true);
+      expect(fuzzyMatch('a{b}', 'Apple{Banana}')).toBe(true);
+      expect(fuzzyMatch('a[b]', 'Apple[Banana]')).toBe(true);
+      expect(fuzzyMatch('a(b)', 'Apple(Banana)')).toBe(true);
+      expect(fuzzyMatch('a|b', 'Apple|Banana')).toBe(true);
+      expect(fuzzyMatch('a\\b', 'Apple\\Banana')).toBe(true);
+    });
+
+    test('should not match when essential characters are missing', () => {
+      expect(fuzzyMatch('xyz', 'Coffee Supreme')).toBe(false);
+      expect(fuzzyMatch('qwerty', 'Coffee')).toBe(false);
+      expect(fuzzyMatch('abc', 'def')).toBe(false);
+    });
+
+    test('should handle edge case with query longer than text', () => {
+      expect(fuzzyMatch('verylongquery', 'short')).toBe(false);
+      expect(fuzzyMatch('coffee', 'cfe')).toBe(false);
+    });
+
+    test('should handle unicode characters', () => {
+      expect(fuzzyMatch('🍕', '🍕 Pizza Place')).toBe(true);
+      expect(fuzzyMatch('中文', '中文餐厅')).toBe(true);
+      expect(fuzzyMatch('αβγ', 'αβγδε')).toBe(true);
+    });
   });
 
   describe('getScrollableListContainer', () => {


### PR DESCRIPTION
## Summary
- enable fuzzy searching by characters-in-order
- add unit tests for fuzzy search functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fee5059b0833093592629640df19f