### PR TITLE
Improve text parsing by traversing nodes

### DIFF
--- a/content.js
+++ b/content.js
@@ -5,6 +5,40 @@ function removeDiacritics(str) {
   return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 }
 
+// Recursively collect all text content from an element
+function extractAllText(element) {
+  if (!element) return '';
+  let text = '';
+  const walker = document.createTreeWalker(
+    element,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+    null,
+    false
+  );
+  let node;
+  while ((node = walker.nextNode())) {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent) {
+      text += ' ' + node.textContent.trim();
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const el = node;
+      const alt = el.getAttribute && el.getAttribute('alt');
+      const aria = el.getAttribute && el.getAttribute('aria-label');
+      const title = el.getAttribute && el.getAttribute('title');
+      const placeholder = el.getAttribute && el.getAttribute('placeholder');
+      if (alt) text += ' ' + alt.trim();
+      if (aria) text += ' ' + aria.trim();
+      if (title) text += ' ' + title.trim();
+      if (placeholder) text += ' ' + placeholder.trim();
+
+      // Include textarea value because user text may not appear as a text node
+      if (el.tagName === 'TEXTAREA' && typeof el.value === 'string') {
+        text += ' ' + el.value.trim();
+      }
+    }
+  }
+  return text.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
 function observeListChanges(listContainer) {
   let lastListIdentifier = getListIdentifier(listContainer);
   let debounceTimer = null;
@@ -133,96 +167,20 @@ function filterPlaces(query, excludeQuery = []) {
     while (itemDiv && (itemDiv === listContainer || !itemDiv.contains(button))) {
       itemDiv = itemDiv.parentElement.closest('div');
     }
-    // If we somehow end up at the listContainer, skip
     if (!itemDiv || itemDiv === listContainer) return;
 
-    let name = '';
-    let typePrice = '';
-    let note = '';
-    const nameElement = button.querySelector('h1, h2, h3, h4, .fontHeadlineSmall');
-
-    if (nameElement && nameElement.textContent.trim()) {
-      name = nameElement.textContent.trim().toLowerCase();
-      let allButtonText = button.textContent.trim().toLowerCase();
-      let normalizedName = name.replace(/\s+/g, ' ');
-      let normalizedAllButtonText = allButtonText.replace(/\s+/g, ' ');
-      if (normalizedAllButtonText.includes(normalizedName)) {
-        typePrice = normalizedAllButtonText.replace(normalizedName, '').trim();
-      } else {
-        typePrice = normalizedAllButtonText;
-      }
-    } else {
-      typePrice = button.textContent.trim().toLowerCase().replace(/\s+/g, ' ');
+    let itemText = extractAllText(itemDiv);
+    const sibling = itemDiv.nextElementSibling;
+    if (
+      sibling && (
+        sibling.matches('div.item-note, span.item-note, div[class*="note"], span[class*="note"]') ||
+        sibling.querySelector('textarea')
+      )
+    ) {
+      itemText += ' ' + extractAllText(sibling);
     }
 
-    // Extract note: 
-    const itemDivNextSibling = itemDiv.nextElementSibling;
-
-    // Path 1: Check if the direct next sibling of itemDiv seems to be a note container (matches E2E fixture structure for item1, item4 notes).
-    if (itemDivNextSibling && itemDivNextSibling.matches('div.item-note, span.item-note, div[class*="note"], span[class*="note"]')) {
-        note = itemDivNextSibling.textContent.trim().toLowerCase();
-    }
-
-    // Path 2: If note not found as a direct sibling, or to ensure we capture textarea notes correctly (e.g., from real Google Maps HTML).
-    if (note === '') { 
-        // Look for textarea with stable attributes (aria-label, placeholder, or data attributes)
-        const noteTextarea = itemDiv.querySelector(
-          'textarea[aria-label*="ote"], textarea[aria-label*="Note"], ' +
-          'textarea[placeholder*="ote"], textarea[placeholder*="Note"], ' +
-          'textarea[data-value], textarea[role="textbox"]'
-        );
-        if (noteTextarea && typeof noteTextarea.value === 'string') {
-            note = noteTextarea.value.trim().toLowerCase();
-        } else {
-            // Fallback: Look for note containers using more stable selectors
-            // Target elements that contain textareas or have note-like content
-            const inlineNoteElement = itemDiv.querySelector(
-              'div[class*="note"], span[class*="note"], ' +
-              'div:has(textarea), span:has(textarea), ' +
-              '[aria-label*="ote"], [data-value], ' +
-              'div[contenteditable="true"], span[contenteditable="true"]'
-            );
-            if (inlineNoteElement) {
-                // If this element wraps a textarea, prioritize textarea's value.
-                const innerTextarea = inlineNoteElement.querySelector(
-                  'textarea[aria-label*="ote"], textarea[placeholder*="ote"], ' +
-                  'textarea[data-value], textarea[role="textbox"]'
-                );
-                if (innerTextarea && typeof innerTextarea.value === 'string') {
-                    note = innerTextarea.value.trim().toLowerCase();
-                } else {
-                    // Otherwise, take the textContent of the found inlineNoteElement itself.
-                    note = inlineNoteElement.textContent.trim().toLowerCase();
-                }
-            }
-        }
-    }
-
-    if ((!name || name.length < 3) && typePrice.length > 0) {
-      const parts = typePrice.split(/\s*·\s*|\s{2,}/);
-      for (const part of parts) {
-        const potentialName = part.trim();
-        if (potentialName.length > 2 && /[a-zA-Z]/.test(potentialName) && !/^\$?\d/.test(potentialName) && !/^\d+(\.\d+)?\s*\$/.test(potentialName)) {
-          name = potentialName;
-          let normalizedTypePrice = typePrice.replace(/\s+/g, ' ');
-          let normalizedNewName = name.replace(/\s+/g, ' ');
-          if (normalizedTypePrice.includes(normalizedNewName)) {
-              typePrice = normalizedTypePrice.replace(normalizedNewName, '').trim();
-          }
-          break; 
-        }
-      }
-      if ((!name || name.length < 3) && parts.length > 0 && parts[0].trim().length > 2 && /[a-zA-Z]/.test(parts[0].trim())){
-          name = parts[0].trim();
-          let normalizedTypePrice = typePrice.replace(/\s+/g, ' ');
-          let normalizedNewName = name.replace(/\s+/g, ' ');
-          if (normalizedTypePrice.includes(normalizedNewName)) {
-              typePrice = normalizedTypePrice.replace(normalizedNewName, '').trim();
-          }
-      }
-    }
-    typePrice = typePrice.replace(/^[^a-zA-Z0-9$]+/, '').trim();
-    itemsToShowOrHide.push({ element: itemDiv, name, typePrice, note });
+    itemsToShowOrHide.push({ element: itemDiv, text: itemText });
   });
 
   // First, make all identified items visible by default
@@ -234,40 +192,30 @@ function filterPlaces(query, excludeQuery = []) {
 
   // Then, apply include and exclude filters
   itemsToShowOrHide.forEach(itemData => {
-    const normalizedName = removeDiacritics(itemData.name);
-    const normalizedTypePrice = removeDiacritics(itemData.typePrice);
-    const normalizedNote = removeDiacritics(itemData.note);
-    
+    const normalizedText = removeDiacritics(itemData.text);
+
     let shouldShow = true;
-    
+
     // Apply include filter (if there's a query)
     if (query && query.length > 0) {
       const normalizedQuery = removeDiacritics(query);
-      const isMatchByName = normalizedName.includes(normalizedQuery);
-      const isMatchByTypePrice = normalizedTypePrice.includes(normalizedQuery);
-      const isMatchByNote = normalizedNote.includes(normalizedQuery);
-      const queryFound = isMatchByName || isMatchByTypePrice || isMatchByNote;
-      
-      if (!queryFound) {
+      if (!normalizedText.includes(normalizedQuery)) {
         shouldShow = false;
       }
     }
-    
+
     // Apply exclude filter (if there are exclude terms)
     if (excludeQuery && excludeQuery.length > 0 && shouldShow) {
       const shouldExclude = excludeQuery.some(excludeTerm => {
         const normalizedExcludeTerm = removeDiacritics(excludeTerm);
-        const isExcludeMatchByName = normalizedName.includes(normalizedExcludeTerm);
-        const isExcludeMatchByTypePrice = normalizedTypePrice.includes(normalizedExcludeTerm);
-        const isExcludeMatchByNote = normalizedNote.includes(normalizedExcludeTerm);
-        return isExcludeMatchByName || isExcludeMatchByTypePrice || isExcludeMatchByNote;
+        return normalizedText.includes(normalizedExcludeTerm);
       });
-      
+
       if (shouldExclude) {
         shouldShow = false;
       }
     }
-    
+
     itemData.element.style.display = shouldShow ? '' : 'none';
   });
 }

--- a/tests/unit/content.test.js
+++ b/tests/unit/content.test.js
@@ -320,7 +320,7 @@ describe('Content Script Unit Tests', () => {
 
     test('should handle diacritics in query and item text', () => {
       // Create item without using the helper's note functionality, then add note manually
-      const item1 = createPlaceItem('item1', 'Café Olé', 'Spanish Bistro', null); 
+      const item1 = createPlaceItem('item1', 'Café Olé', 'Spanish Bistro', null);
       const noteEl = document.createElement('div');
       noteEl.textContent = 'Serves Pâtisserie';
       noteEl.className = 'item-note'; // Added class for detection
@@ -329,12 +329,31 @@ describe('Content Script Unit Tests', () => {
 
       filterPlaces('cafe ole');
       expect(item1.style.display).toBe('');
-      
+
       filterPlaces('patisserie');
       expect(item1.style.display).toBe('');
-      
+
       filterPlaces('bistro');
       expect(item1.style.display).toBe('');
+    });
+
+    test('should extract textarea content for filtering', () => {
+      const itemDiv = document.createElement('div');
+      const button = document.createElement('button');
+      button.innerHTML = '<img src="fake.jpg"><h3 class="fontHeadlineSmall">Veg Stall</h3>';
+      itemDiv.appendChild(button);
+      const noteContainer = document.createElement('div');
+      const textarea = document.createElement('textarea');
+      textarea.value = 'indian vege \ud83d\ude05';
+      noteContainer.appendChild(textarea);
+      itemDiv.appendChild(noteContainer);
+      listContainer.appendChild(itemDiv);
+
+      filterPlaces('indian');
+      expect(itemDiv.style.display).toBe('');
+
+      filterPlaces('', ['indian']);
+      expect(itemDiv.style.display).toBe('none');
     });
 
     test('should correctly identify parent div for hiding/showing complex structures', () => {


### PR DESCRIPTION
## Summary
- extract text from aria-label, title, and alt attributes when parsing list items
- capture textarea values and placeholder text when extracting text
- detect textarea-based notes when filtering
- test textarea extraction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b8459f9d883308f04717601149b2c