### PR TITLE
Automate manifest version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ maps-filter-extension/
 │   ├── icon_16x16.png
 │   ├── icon_48x48.png
 │   └── icon_128x128.png
+├── package.sh         # Version bump + packaging wrapper
 ├── scripts/           # Build and utility scripts
 │   └── pack.sh        # Distribution packaging script
 ├── tests/             # Test suite
@@ -124,14 +125,14 @@ maps-filter-extension/
 
 ### Building for Distribution
 ```bash
-# Make sure the pack script is executable
-chmod +x scripts/pack.sh
+# Make sure the package script is executable
+chmod +x package.sh
 
-# Create a distribution package
-./scripts/pack.sh
+# Create a distribution package (automatically bumps the version)
+./package.sh
 ```
 
-This creates a `google-maps-list-filter-v1.0.zip` file ready for store submission.
+This creates a `google-maps-list-filter-v<version>.zip` file ready for store submission.
 
 ## 🧪 Testing
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Google Maps List Filter",
-  "version": "1.0",
+  "version": "1.0.1",
   "description": "Easily search and filter your saved places in Google Maps lists by name, type, price, or notes with a convenient search overlay",
   "permissions": [],
   "icons": {
@@ -11,9 +11,16 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.google.com/maps/*", "file://*/*"],
-      "js": ["content.js"],
-      "css": ["style.css"]
+      "matches": [
+        "https://www.google.com/maps/*",
+        "file://*/*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "css": [
+        "style.css"
+      ]
     }
   ],
   "action": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maps-filter-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "content.js",
   "scripts": {

--- a/package.sh
+++ b/package.sh
@@ -1,3 +1,14 @@
 #!/bin/bash
 # Convenience wrapper for the packaging script
-./scripts/pack.sh "$@" 
+# Automatically bump the extension version before packaging
+
+set -e
+
+# Bump patch version in package.json without creating a git tag
+NEW_VERSION=$(npm version patch --no-git-tag-version | tr -d 'v')
+
+# Update manifest.json with the new version
+jq --arg v "$NEW_VERSION" '.version = $v' manifest.json > manifest.tmp && mv manifest.tmp manifest.json
+
+# Run the actual packaging script
+./scripts/pack.sh "$@"


### PR DESCRIPTION
## Summary
- bump extension version automatically in `package.sh`
- mention the version bump step in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684be8fae20483308d7ad20550962d94