### PR TITLE
Add multi-language support

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "مرشح قوائم خرائط Google"},
+  "extensionDescription": {"message": "ابحث وفلتر أماكنك المحفوظة في قوائم خرائط Google بسهولة حسب الاسم أو النوع أو السعر أو الملاحظات باستخدام مربع بحث ملائم"},
+  "extensionActionTitle": {"message": "مرشح الخرائط"},
+  "filterPlaceholder": {"message": "فرز الأماكن حسب الاسم أو النوع أو السعر أو الملاحظات..."},
+  "hintExclude": {"message": "تلميح: استخدم ‎-كلمة لاستبعادها"},
+  "exampleLine": {"message": "أمثلة: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "جاري تحميل جميع الأماكن..."},
+  "loadingNewList": {"message": "جاري تحميل القائمة الجديدة..."},
+  "loadingPlacesProgress": {"message": "جاري تحميل الأماكن... (تم العثور على ‎$1)"},
+  "allPlacesLoaded": {"message": "تم تحميل كل الأماكن!"},
+  "newListLoaded": {"message": "تم تحميل القائمة الجديدة!"}
+}

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "গুগল ম্যাপস তালিকা ফিল্টার"},
+  "extensionDescription": {"message": "সুবিধাজনক সার্চ বক্স দিয়ে নাম, ধরন, দাম বা নোট অনুযায়ী গুগল ম্যাপসের তালিকায় সংরক্ষিত স্থান সহজে খুঁজুন ও ফিল্টার করুন"},
+  "extensionActionTitle": {"message": "ম্যাপস ফিল্টার"},
+  "filterPlaceholder": {"message": "নাম, ধরন, দাম বা নোট দিয়ে স্থান ফিল্টার করুন..."},
+  "hintExclude": {"message": "ইঙ্গিত: বাদ দিতে -শব্দ ব্যবহার করুন"},
+  "exampleLine": {"message": "উদাহরণ: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "সব স্থান লোড হচ্ছে..."},
+  "loadingNewList": {"message": "নতুন তালিকা লোড হচ্ছে..."},
+  "loadingPlacesProgress": {"message": "স্থান লোড হচ্ছে... ($1টি পাওয়া গেছে)"},
+  "allPlacesLoaded": {"message": "সব স্থান লোড সম্পন্ন!"},
+  "newListLoaded": {"message": "নতুন তালিকা লোড সম্পন্ন!"}
+}

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Google-Maps-Listenfilter"},
+  "extensionDescription": {"message": "Durchsuchen und filtern Sie Ihre gespeicherten Orte in Google-Maps-Listen bequem nach Name, Typ, Preis oder Notizen über ein praktisches Suchfeld"},
+  "extensionActionTitle": {"message": "Maps-Filter"},
+  "filterPlaceholder": {"message": "Orte nach Name, Typ, Preis oder Notizen filtern..."},
+  "hintExclude": {"message": "Tipp: Verwende -Wort, um auszuschließen"},
+  "exampleLine": {"message": "Beispiele: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "Alle Orte werden geladen..."},
+  "loadingNewList": {"message": "Neue Liste wird geladen..."},
+  "loadingPlacesProgress": {"message": "Orte werden geladen... ($1 gefunden)"},
+  "allPlacesLoaded": {"message": "Alle Orte geladen!"},
+  "newListLoaded": {"message": "Neue Liste geladen!"}
+}

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Google Maps List Filter"},
+  "extensionDescription": {"message": "Easily search and filter your saved places in Google Maps lists by name, type, price, or notes with a convenient search overlay"},
+  "extensionActionTitle": {"message": "Maps Filter"},
+  "filterPlaceholder": {"message": "Filter places by name, type, price, or notes..."},
+  "hintExclude": {"message": "Hint: use -word to exclude"},
+  "exampleLine": {"message": "Examples: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "Loading all places..."},
+  "loadingNewList": {"message": "Loading new list..."},
+  "loadingPlacesProgress": {"message": "Loading places... ($1 found)"},
+  "allPlacesLoaded": {"message": "All places loaded!"},
+  "newListLoaded": {"message": "New list loaded!"}
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Filtro de Listas de Google Maps"},
+  "extensionDescription": {"message": "Busca y filtra fácilmente tus lugares guardados en las listas de Google Maps por nombre, tipo, precio o notas mediante un práctico cuadro de búsqueda"},
+  "extensionActionTitle": {"message": "Filtro de Maps"},
+  "filterPlaceholder": {"message": "Filtrar lugares por nombre, tipo, precio o notas..."},
+  "hintExclude": {"message": "Consejo: usa -palabra para excluir"},
+  "exampleLine": {"message": "Ejemplos: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "Cargando todos los lugares..."},
+  "loadingNewList": {"message": "Cargando nueva lista..."},
+  "loadingPlacesProgress": {"message": "Cargando lugares... ($1 encontrados)"},
+  "allPlacesLoaded": {"message": "¡Todos los lugares cargados!"},
+  "newListLoaded": {"message": "¡Nueva lista cargada!"}
+}

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Filtre de listes Google Maps"},
+  "extensionDescription": {"message": "Recherchez et filtrez facilement vos lieux enregistrés dans les listes Google Maps par nom, type, prix ou notes grâce à une zone de recherche pratique"},
+  "extensionActionTitle": {"message": "Filtre Maps"},
+  "filterPlaceholder": {"message": "Filtrer les lieux par nom, type, prix ou notes..."},
+  "hintExclude": {"message": "Astuce : utilisez -mot pour exclure"},
+  "exampleLine": {"message": "Exemples : \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "Chargement de tous les lieux..."},
+  "loadingNewList": {"message": "Chargement de la nouvelle liste..."},
+  "loadingPlacesProgress": {"message": "Chargement des lieux... ($1 trouvés)"},
+  "allPlacesLoaded": {"message": "Tous les lieux chargés !"},
+  "newListLoaded": {"message": "Nouvelle liste chargée !"}
+}

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Google Maps सूची फ़िल्टर"},
+  "extensionDescription": {"message": "सुविधाजनक खोज बॉक्स से नाम, प्रकार, कीमत या नोट्स के अनुसार Google Maps सूचियों में सेव किए गए स्थानों को आसानी से खोजें और फ़िल्टर करें"},
+  "extensionActionTitle": {"message": "मैप्स फ़िल्टर"},
+  "filterPlaceholder": {"message": "नाम, प्रकार, कीमत या नोट्स से स्थान फ़िल्टर करें..."},
+  "hintExclude": {"message": "सुझाव: किसी शब्द को हटाने के लिए -word प्रयोग करें"},
+  "exampleLine": {"message": "उदाहरण: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "सभी स्थान लोड हो रहे हैं..."},
+  "loadingNewList": {"message": "नई सूची लोड हो रही है..."},
+  "loadingPlacesProgress": {"message": "स्थान लोड हो रहे हैं... ($1 मिले)"},
+  "allPlacesLoaded": {"message": "सभी स्थान लोड हो गए!"},
+  "newListLoaded": {"message": "नई सूची लोड हो गई!"}
+}

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Filter Daftar Google Maps"},
+  "extensionDescription": {"message": "Cari dan saring tempat yang disimpan di daftar Google Maps dengan mudah berdasarkan nama, jenis, harga, atau catatan menggunakan kotak pencarian yang praktis"},
+  "extensionActionTitle": {"message": "Filter Maps"},
+  "filterPlaceholder": {"message": "Saring tempat berdasarkan nama, jenis, harga, atau catatan..."},
+  "hintExclude": {"message": "Tip: gunakan -kata untuk mengecualikan"},
+  "exampleLine": {"message": "Contoh: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "Memuat semua tempat..."},
+  "loadingNewList": {"message": "Memuat daftar baru..."},
+  "loadingPlacesProgress": {"message": "Memuat tempat... ($1 ditemukan)"},
+  "allPlacesLoaded": {"message": "Semua tempat telah dimuat!"},
+  "newListLoaded": {"message": "Daftar baru dimuat!"}
+}

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Google マップ リストフィルター"},
+  "extensionDescription": {"message": "便利な検索ボックスで名前、種類、価格、メモから Google マップの保存済みリストを簡単に検索・フィルタリング"},
+  "extensionActionTitle": {"message": "マップフィルター"},
+  "filterPlaceholder": {"message": "名前、種類、価格、メモで場所を絞り込み..."},
+  "hintExclude": {"message": "ヒント: 除外するには -単語 を使用"},
+  "exampleLine": {"message": "例: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "すべての場所を読み込み中..."},
+  "loadingNewList": {"message": "新しいリストを読み込み中..."},
+  "loadingPlacesProgress": {"message": "場所を読み込み中...（$1 件）"},
+  "allPlacesLoaded": {"message": "すべての場所を読み込みました!"},
+  "newListLoaded": {"message": "新しいリストを読み込みました!"}
+}

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "구글 지도 목록 필터"},
+  "extensionDescription": {"message": "편리한 검색 상자를 사용하여 이름, 유형, 가격 또는 메모로 구글 지도 목록에 저장된 장소를 쉽게 검색하고 필터링하세요"},
+  "extensionActionTitle": {"message": "지도 필터"},
+  "filterPlaceholder": {"message": "이름, 유형, 가격 또는 메모로 장소 필터..."},
+  "hintExclude": {"message": "팁: 제외하려면 -단어 사용"},
+  "exampleLine": {"message": "예: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "모든 장소 불러오는 중..."},
+  "loadingNewList": {"message": "새 목록 불러오는 중..."},
+  "loadingPlacesProgress": {"message": "장소 불러오는 중... ($1개 찾음)"},
+  "allPlacesLoaded": {"message": "모든 장소를 불러왔습니다!"},
+  "newListLoaded": {"message": "새 목록을 불러왔습니다!"}
+}

--- a/_locales/mr/messages.json
+++ b/_locales/mr/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Google Maps सूची फिल्टर"},
+  "extensionDescription": {"message": "सोयीच्या शोध बॉक्सद्वारे नाव, प्रकार, किंमत किंवा नोंदींनुसार Google Maps याद्यांमधील जतन केलेली ठिकाणे सहज शोधा आणि फिल्टर करा"},
+  "extensionActionTitle": {"message": "नकाशे फिल्टर"},
+  "filterPlaceholder": {"message": "नाव, प्रकार, किंमत किंवा नोंदींवरून ठिकाणे फिल्टर करा..."},
+  "hintExclude": {"message": "सूचना: वगळण्यासाठी -शब्द वापरा"},
+  "exampleLine": {"message": "उदाहरणे: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "सर्व ठिकाणे लोड होत आहेत..."},
+  "loadingNewList": {"message": "नवीन यादी लोड होत आहे..."},
+  "loadingPlacesProgress": {"message": "ठिकाणे लोड होत आहेत... ($1 आढळले)"},
+  "allPlacesLoaded": {"message": "सर्व ठिकाणे लोड झाली!"},
+  "newListLoaded": {"message": "नवीन यादी लोड झाली!"}
+}

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Filtro de Listas do Google Maps"},
+  "extensionDescription": {"message": "Pesquise e filtre facilmente seus locais salvos em listas do Google Maps por nome, tipo, preço ou notas com uma prática caixa de pesquisa"},
+  "extensionActionTitle": {"message": "Filtro do Maps"},
+  "filterPlaceholder": {"message": "Filtrar locais por nome, tipo, preço ou notas..."},
+  "hintExclude": {"message": "Dica: use -palavra para excluir"},
+  "exampleLine": {"message": "Exemplos: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "Carregando todos os locais..."},
+  "loadingNewList": {"message": "Carregando nova lista..."},
+  "loadingPlacesProgress": {"message": "Carregando locais... ($1 encontrados)"},
+  "allPlacesLoaded": {"message": "Todos os locais carregados!"},
+  "newListLoaded": {"message": "Nova lista carregada!"}
+}

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Фильтр списков Google Карт"},
+  "extensionDescription": {"message": "Удобно ищите и фильтруйте сохранённые места в списках Google Карт по названию, типу, цене или заметкам"},
+  "extensionActionTitle": {"message": "Фильтр карт"},
+  "filterPlaceholder": {"message": "Фильтровать места по названию, типу, цене или заметкам..."},
+  "hintExclude": {"message": "Подсказка: используйте -слово для исключения"},
+  "exampleLine": {"message": "Примеры: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "Загрузка всех мест..."},
+  "loadingNewList": {"message": "Загрузка нового списка..."},
+  "loadingPlacesProgress": {"message": "Загрузка мест... (найдено: $1)"},
+  "allPlacesLoaded": {"message": "Все места загружены!"},
+  "newListLoaded": {"message": "Новый список загружен!"}
+}

--- a/_locales/sw/messages.json
+++ b/_locales/sw/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Kichujio cha Orodha za Google Maps"},
+  "extensionDescription": {"message": "Tafuta na uchuje kwa urahisi maeneo uliyo hifadhi katika orodha za Google Maps kwa jina, aina, bei au maelezo ukitumia kisanduku cha utafutaji rahisi"},
+  "extensionActionTitle": {"message": "Kichujio cha Ramani"},
+  "filterPlaceholder": {"message": "Chuja maeneo kwa jina, aina, bei au maelezo..."},
+  "hintExclude": {"message": "Dokezo: tumia -neno kuondoa"},
+  "exampleLine": {"message": "Mifano: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "Inapakia maeneo yote..."},
+  "loadingNewList": {"message": "Inapakia orodha mpya..."},
+  "loadingPlacesProgress": {"message": "Inapakia maeneo... ($1 yamepatikana)"},
+  "allPlacesLoaded": {"message": "Maeneo yote yamepakiwa!"},
+  "newListLoaded": {"message": "Orodha mpya imepakiwa!"}
+}

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Google Maps பட்டியல் வடிகட்டி"},
+  "extensionDescription": {"message": "பெயர், வகை, விலை அல்லது குறிப்புகளை அடிப்படையாகக் கொண்டு Google Maps பட்டியலில் சேமித்துள்ள இடங்களை எளிதாக தேடி வடிகட்ட பயன்பயன்பாடு"},
+  "extensionActionTitle": {"message": "வரைபட வடிகட்டி"},
+  "filterPlaceholder": {"message": "பெயர், வகை, விலை அல்லது குறிப்புகள் மூலம் இடங்களை வடிகட்டி..."},
+  "hintExclude": {"message": "குறிப்பு: நீக்க -வார்த்தை பயன்படுத்தவும்"},
+  "exampleLine": {"message": "எடுத்துக்காட்டு: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "அனைத்து இடங்களையும் ஏற்றுகிறது..."},
+  "loadingNewList": {"message": "புதிய பட்டியலை ஏற்றுகிறது..."},
+  "loadingPlacesProgress": {"message": "இடங்கள் ஏற்றப்படுகிறது... ($1 கண்டம்)"},
+  "allPlacesLoaded": {"message": "அனைத்து இடங்களும் ஏற்றப்பட்டன!"},
+  "newListLoaded": {"message": "புதிய பட்டியல் ஏற்றப்பட்டது!"}
+}

--- a/_locales/te/messages.json
+++ b/_locales/te/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Google Maps జాబితా ఫిల్టర్"},
+  "extensionDescription": {"message": "సౌకర్యవంతమైన శోధన బాక్స్ ద్వారా పేరు, రకం, ధర లేదా గమనికల ఆధారంగా Google Maps జాబితాల్లో మీరు సేవ్ చేసిన ప్రదేశాలను సులభంగా శోధించి ఫిల్టర్ చేయండి"},
+  "extensionActionTitle": {"message": "మ్యాప్‌లు ఫిల్టర్"},
+  "filterPlaceholder": {"message": "పేరు, రకం, ధర లేదా గమనికల ద్వారా ప్రదేశాలను వడపోసు..."},
+  "hintExclude": {"message": "సూచన: తొలగించడానికి -పదాన్ని ఉపయోగించండి"},
+  "exampleLine": {"message": "ఉదాహరణలు: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "అన్ని ప్రదేశాలు లోడ్ అవుతున్నాయి..."},
+  "loadingNewList": {"message": "కొత్త జాబితా లోడ్ అవుతోంది..."},
+  "loadingPlacesProgress": {"message": "ప్రదేశాలు లోడ్ అవుతున్నాయి... ($1 కనుగొనబడింది)"},
+  "allPlacesLoaded": {"message": "అన్ని ప్రదేశాలు లోడ్ అయ్యాయి!"},
+  "newListLoaded": {"message": "కొత్త జాబితా లోడ్ అయింది!"}
+}

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Google Haritalar Liste Filtresi"},
+  "extensionDescription": {"message": "Kullanışlı bir arama kutusuyla isim, tür, fiyat veya notlara göre Google Haritalar listelerinizde kaydedilen yerleri kolayca arayın ve filtreleyin"},
+  "extensionActionTitle": {"message": "Harita Filtresi"},
+  "filterPlaceholder": {"message": "Yerleri isme, türe, fiyata veya notlara göre filtrele..."},
+  "hintExclude": {"message": "İpucu: hariç tutmak için -kelime kullanın"},
+  "exampleLine": {"message": "Örnekler: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "Tüm yerler yükleniyor..."},
+  "loadingNewList": {"message": "Yeni liste yükleniyor..."},
+  "loadingPlacesProgress": {"message": "Yerler yükleniyor... ($1 bulundu)"},
+  "allPlacesLoaded": {"message": "Tüm yerler yüklendi!"},
+  "newListLoaded": {"message": "Yeni liste yüklendi!"}
+}

--- a/_locales/ur/messages.json
+++ b/_locales/ur/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "گوگل میپس لسٹ فلٹر"},
+  "extensionDescription": {"message": "آسان سرچ باکس کے ذریعے نام، قسم، قیمت یا نوٹس کے حساب سے گوگل میپس کی فہرستوں میں محفوظ مقامات کو باآسانی تلاش کریں اور فلٹر کریں"},
+  "extensionActionTitle": {"message": "میپس فلٹر"},
+  "filterPlaceholder": {"message": "نام، قسم، قیمت یا نوٹس سے مقامات فلٹر کریں..."},
+  "hintExclude": {"message": "اشارہ: کسی لفظ کو نکالنے کے لیے -word استعمال کریں"},
+  "exampleLine": {"message": "مثالیں: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "تمام مقامات لوڈ ہو رہے ہیں..."},
+  "loadingNewList": {"message": "نئی فہرست لوڈ ہو رہی ہے..."},
+  "loadingPlacesProgress": {"message": "مقامات لوڈ ہو رہے ہیں... ($1 ملا)"},
+  "allPlacesLoaded": {"message": "تمام مقامات لوڈ ہو گئے!"},
+  "newListLoaded": {"message": "نئی فہرست لوڈ ہو گئی!"}
+}

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Bộ lọc danh sách Google Maps"},
+  "extensionDescription": {"message": "Tìm kiếm và lọc các địa điểm đã lưu trong danh sách Google Maps theo tên, loại, giá hoặc ghi chú một cách dễ dàng bằng hộp tìm kiếm tiện lợi"},
+  "extensionActionTitle": {"message": "Bộ lọc Maps"},
+  "filterPlaceholder": {"message": "Lọc địa điểm theo tên, loại, giá hoặc ghi chú..."},
+  "hintExclude": {"message": "Mẹo: dùng -từ để loại bỏ"},
+  "exampleLine": {"message": "Ví dụ: \"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "Đang tải tất cả địa điểm..."},
+  "loadingNewList": {"message": "Đang tải danh sách mới..."},
+  "loadingPlacesProgress": {"message": "Đang tải địa điểm... (đã tìm thấy $1)"},
+  "allPlacesLoaded": {"message": "Đã tải xong tất cả địa điểm!"},
+  "newListLoaded": {"message": "Đã tải xong danh sách mới!"}
+}

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": {"message": "Google 地图列表筛选器"},
+  "extensionDescription": {"message": "通过便捷的搜索框，按名称、类别、价格或备注轻松搜索和筛选你在 Google 地图列表中保存的地点"},
+  "extensionActionTitle": {"message": "地图筛选"},
+  "filterPlaceholder": {"message": "按名称、类别、价格或备注筛选地点..."},
+  "hintExclude": {"message": "提示：用 -单词 排除"},
+  "exampleLine": {"message": "示例：\"restaurant -expensive\", \"mala -✅\""},
+  "loadingAll": {"message": "正在加载所有地点..."},
+  "loadingNewList": {"message": "正在加载新列表..."},
+  "loadingPlacesProgress": {"message": "正在加载地点...（已找到 $1 个）"},
+  "allPlacesLoaded": {"message": "所有地点已加载！"},
+  "newListLoaded": {"message": "新列表已加载！"}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "Google Maps List Filter",
+  "name": "__MSG_extensionName__",
   "version": "1.0.1",
-  "description": "Easily search and filter your saved places in Google Maps lists by name, type, price, or notes with a convenient search overlay",
+  "description": "__MSG_extensionDescription__",
+  "default_locale": "en",
   "permissions": [],
   "icons": {
     "16": "icons/icon_16x16.png",
@@ -24,6 +25,6 @@
     }
   ],
   "action": {
-    "default_title": "Maps Filter"
+    "default_title": "__MSG_extensionActionTitle__"
   }
 }


### PR DESCRIPTION
## Summary
- add `default_locale` and i18n placeholders in manifest
- implement `i18n` helper in content script
- replace hardcoded strings with localized messages
- add `_locales` folder with translations for 20 languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e29eef048330b7fec16841899a2f